### PR TITLE
Add java files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,9 @@ sympy-plots-for-*.tex/
 # WinEdt
 *.bak
 *.sav
+
+# java files
+*.class
+*.jar
+*.i7
+


### PR DESCRIPTION
Inevitably java files will be added to this project and so the gitignore file must have java class files in it.
